### PR TITLE
Anticipated the reset of 'delayedecorder' variable

### DIFF
--- a/ide/main/src/content/recorder-handlers.js
+++ b/ide/main/src/content/recorder-handlers.js
@@ -196,8 +196,9 @@ Recorder.addEventHandler('nodeRemoved', 'DOMNodeRemoved', function(event) {
 
 Recorder.prototype.domModified = function() {
     if (this.delayedRecorder) {
-        this.delayedRecorder.apply(this);
+        var handler = this.delayedRecorder;
         this.delayedRecorder = null;
+        handler.apply(this);
         if (this.domModifiedTimeout) {
             clearTimeout(this.domModifiedTimeout);
         }


### PR DESCRIPTION
1) is detected a click on an element and the handler is saved in 'delayedRecorder' variable while checking if the click is meaningful (callIfMeaningfulEvent function).
2) a DOM change event identify the 'click' as meaningful and the 'domModified' function execute the handler to record the command.
3) if during this execution in the recording code itself or in an delayed code execution on the same element is fired a DOM change event, the handler stored in 'delayedRecorder' will be executed another time because the variable is still valorized. This will record a doubleClick instead of single one.

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
